### PR TITLE
Create multiple anti-affinity groups if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Support zero count for nodes and LBs ([#13])
+- Create multiple anti-affinity groups for a node group if necessary ([#15])
 
 [Unreleased]: https://github.com/appuio/terraform-openshift4-cloudscale/compare/2be86c4...HEAD
 
 [#13]: https://github.com/appuio/terraform-openshift4-cloudscale/pull/13
+[#15]: https://github.com/appuio/terraform-openshift4-cloudscale/pull/15


### PR DESCRIPTION
On Cloudscale, a single anti-affinity group can contain at most four instances currently. The code so far did not take that limit into
account, and thus fails when trying to create a node group with more than four instances.

This commit changes the code to create multiple affinity groups if necessary, by calculating how many groups are needed, and placing instances into different groups based on their Terraform index.

The anti-affinity group capacity is represented by  the local value "anti_affinity_capacity", to avoid the magic number 4 sprinkled throughout the code.