### PR TITLE
Ignore changes which trigger recreates for cloudscale_server resources

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -150,6 +150,11 @@ resource "cloudscale_server" "lb" {
     network_uuid = cloudscale_network.privnet.id
   }
   lifecycle {
+    ignore_changes = [
+      skip_waiting_for_ssh_host_keys,
+      image_slug,
+      user_data,
+    ]
     create_before_destroy = true
   }
 

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -66,4 +66,12 @@ resource "cloudscale_server" "node" {
       }
     }
     EOF
+
+  lifecycle {
+    ignore_changes = [
+      skip_waiting_for_ssh_host_keys,
+      image_slug,
+      user_data,
+    ]
+  }
 }


### PR DESCRIPTION
Ignore changes to parameters `skip_waiting_for_ssh_host_keys`, `image_slug` and `user_data` which trigger recreation of the cloudscale_server resources after the resources have been created.

None of these parameters have an effect if the VM already exists.

Changes that would be propagated via `user_data` and `image_slug` are managed by OCP4 once the VM is part of the cluster, and `skip_waiting_for_ssh_host_keys` also only has an effect during first boot.