### PR TITLE
Implement support for additional worker groups

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,5 +1,14 @@
 terraform {
   required_version = ">= 0.14"
+  // Use experimental feature to allow making object fields optional, cf.
+  // https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
+  //
+  // While there's no guarantee this feature doesn't see breaking changes even
+  // in minor releases, I think the upsides to allow users to omit some
+  // configurations for additional worker groups (e.g. node state, disk size)
+  // outweigh potential changes that we need to make in the future.
+  // -SG, 2021-08-02
+  experiments = [module_variable_optional_attrs]
   required_providers {
     cloudscale = {
       source  = "cloudscale-ch/cloudscale"

--- a/worker.tf
+++ b/worker.tf
@@ -13,3 +13,23 @@ module "worker" {
   ignition_ca      = var.ignition_ca
   api_int          = "api-int.${local.node_name_suffix}"
 }
+
+// Additional worker groups.
+// Configured from var.additional_worker_groups
+module "additional_worker" {
+  for_each = var.additional_worker_groups
+
+  source = "./modules/node-group"
+
+  cluster_id       = var.cluster_id
+  region           = var.region
+  role             = each.key
+  node_count       = each.value.count
+  node_name_suffix = local.node_name_suffix
+  image_slug       = var.image_slug
+  flavor_slug      = each.value.flavor
+  volume_size_gb   = each.value.volume_size_gb != null ? each.value.volume_size_gb : var.worker_volume_size_gb
+  subnet_uuid      = cloudscale_subnet.privnet_subnet.id
+  ignition_ca      = var.ignition_ca
+  api_int          = "api-int.${local.node_name_suffix}"
+}


### PR DESCRIPTION
If no volume size is given for an additional worker group, additional worker groups use `var.worker_volume_size_gb` as root volume size.