### PR TITLE
Prevent LBs from being renamed

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -2,10 +2,6 @@ resource "random_id" "lb" {
   count       = var.lb_count
   prefix      = "lb-"
   byte_length = 1
-  keepers = {
-    api_eip       = cidrhost(cloudscale_floating_ip.api_vip[0].network, 0)
-    infra_servers = join(",", module.infra.ip_addresses)
-  }
 }
 
 resource "cloudscale_server_group" "lb" {


### PR DESCRIPTION
The keepers on the LB's "random_id" are obsolete and cause the LBs to be
renamed after the infra hosts are deployed.

The IP's are managed via Puppet so redeploying the hosts is not
necessary.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
