### PR TITLE
Fix validation for `additional_worker_groups.count` to allow 0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "additional_worker_groups" {
     condition = alltrue([
       for k, v in var.additional_worker_groups :
       !contains(["worker", "master", "infra"], k) &&
-      v.count > 0 &&
+      v.count >= 0 &&
       (v.volume_size_gb != null ? v.volume_size_gb >= 120 : true)
     ])
     // Cannot use any of the nicer string formatting options because


### PR DESCRIPTION
Reported in https://github.com/appuio/terraform-openshift4-exoscale/issues/21

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
