### PR TITLE
Make `subnet_uuid` optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,7 @@ variable "ssh_keys" {
 variable "subnet_uuid" {
   type        = string
   description = "UUID of the subnet in which to create the VMs"
+  default     = ""
 }
 
 variable "privnet_cidr" {


### PR DESCRIPTION
This PR makes `subnet_uuid` optional.
`subnet_uuid` is is allowed and expected to be empty in code already.

Fixes an oversight in #29.

https://github.com/appuio/terraform-openshift4-cloudscale/blob/bcd563963f230655a7099464409134e9afa973b0/main.tf#L3-L4

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
