### PR TITLE
Add variable privnet_uuid

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -5,7 +5,7 @@ module "lb" {
   cluster_id             = var.cluster_id
   region                 = var.region
   ssh_keys               = var.ssh_keys
-  privnet_id             = cloudscale_network.privnet[0].id
+  privnet_id             = local.privnet_uuid
   lb_count               = var.lb_count
   control_vshn_net_token = var.control_vshn_net_token
 

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   node_name_suffix      = "${var.cluster_id}.${var.base_domain}"
   create_privnet_subnet = var.subnet_uuid == "" ? 1 : 0
   subnet_uuid           = var.subnet_uuid == "" ? cloudscale_subnet.privnet_subnet[0].id : var.subnet_uuid
+  privnet_uuid          = var.privnet_uuid == "" ? cloudscale_network.privnet[0].id : var.privnet_uuid
 }
 
 resource "cloudscale_network" "privnet" {
@@ -13,7 +14,7 @@ resource "cloudscale_network" "privnet" {
 
 resource "cloudscale_subnet" "privnet_subnet" {
   count           = local.create_privnet_subnet
-  network_uuid    = cloudscale_network.privnet[0].id
+  network_uuid    = local.privnet_uuid
   cidr            = var.privnet_cidr
   gateway_address = cidrhost(var.privnet_cidr, 1)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "subnet_uuid" {
   default     = ""
 }
 
+variable "privnet_uuid" {
+  type        = string
+  description = "UUID of an existing private network"
+  default     = ""
+}
+
 variable "privnet_cidr" {
   default     = "172.18.200.0/24"
   description = "CIDR for the private network. This must match the CIDR of the existing subnet, if the variable subnet_uuid is set."

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "subnet_uuid" {
 
 variable "privnet_uuid" {
   type        = string
-  description = "UUID of an existing private network"
+  description = "UUID of an existing private network. If provided, variables `privnet_cidr` and `subnet_uuid` must be set to point to a subnet which is part of the provided private network."
   default     = ""
 }
 

--- a/worker.tf
+++ b/worker.tf
@@ -29,7 +29,7 @@ module "additional_worker" {
   image_slug       = var.image_slug
   flavor_slug      = each.value.flavor
   volume_size_gb   = each.value.volume_size_gb != null ? each.value.volume_size_gb : var.worker_volume_size_gb
-  subnet_uuid      = cloudscale_subnet.privnet_subnet[0].id
+  subnet_uuid      = local.subnet_uuid
   ignition_ca      = var.ignition_ca
   api_int          = "api-int.${local.node_name_suffix}"
 }


### PR DESCRIPTION
To use an existing subnet, the uuid of the private network needs to be supplied as well. 

Related error message:
```
Error: Invalid index

  on .terraform/modules/cluster/lb.tf line 8, in module "lb":
   8:   privnet_id             = cloudscale_network.privnet[0].id
    |----------------
    | cloudscale_network.privnet is empty tuple
```

I wasn't able to test these changes yet, as I couldn't find a way to tell `component-openshift4-terraform` to use a branch of this repo.
Also it would probably be good to add a note somewhere, that the variables `subnet_uuid`, `privnet_uuid` and `privnet_cidr` all need to be set and matching. Should/can this be checked or even enforced?

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
