### PR TITLE
Default image slug should match the value used in the install docs

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ variable "additional_worker_groups" {
 variable "image_slug" {
   type        = string
   description = "Image to use for nodes"
-  default     = "custom:rhcos-4.7"
+  default     = "custom:rhcos-4.8"
 }
 
 variable "lb_cloudscale_api_secret" {


### PR DESCRIPTION
https://github.com/appuio/openshift4-docs/blob/master/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc#upload-red-hat-coreos-image suggests to use the 4.8 image, therefore the default value should reflect this. Otherwise terraform throws an error about not finding the image until you manually change the image_slug in the cluster.yaml to the correct version.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
