### PR TITLE
Introduce separate variable `cluster_name`

### DIFF
--- a/infra.tf
+++ b/infra.tf
@@ -1,7 +1,6 @@
 module "infra" {
   source = "./modules/node-group"
 
-  cluster_id       = var.cluster_id
   region           = var.region
   role             = "infra"
   node_count       = var.infra_count

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  node_name_suffix      = "${var.cluster_id}.${var.base_domain}"
+  cluster_name          = var.cluster_name != "" ? var.cluster_name : var.cluster_id
+  node_name_suffix      = "${local.cluster_name}.${var.base_domain}"
   create_privnet_subnet = var.subnet_uuid == "" ? 1 : 0
   subnet_uuid           = var.subnet_uuid == "" ? cloudscale_subnet.privnet_subnet[0].id : var.subnet_uuid
   privnet_uuid          = var.privnet_uuid == "" ? cloudscale_network.privnet[0].id : var.privnet_uuid

--- a/master.tf
+++ b/master.tf
@@ -1,7 +1,6 @@
 module "master" {
   source = "./modules/node-group"
 
-  cluster_id       = var.cluster_id
   region           = var.region
   role             = "master"
   ignition_config  = "master"

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -23,11 +23,6 @@ variable "region" {
   description = "Region where to deploy nodes"
 }
 
-variable "cluster_id" {
-  type        = string
-  description = "ID of the cluster"
-}
-
 variable "flavor_slug" {
   type        = string
   description = "Flavor to use for nodes"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "cluster_id" {
   type        = string
-  description = "ID of the cluster"
+  description = "Project Syn ID of the cluster"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "User-facing name of the cluster. If left empty, cluster_id will be used as cluster_name"
+  default     = ""
 }
 
 variable "ignition_bootstrap" {

--- a/worker.tf
+++ b/worker.tf
@@ -1,7 +1,6 @@
 module "worker" {
   source = "./modules/node-group"
 
-  cluster_id       = var.cluster_id
   region           = var.region
   role             = "worker"
   node_count       = var.worker_count
@@ -21,7 +20,6 @@ module "additional_worker" {
 
   source = "./modules/node-group"
 
-  cluster_id       = var.cluster_id
   region           = var.region
   role             = each.key
   node_count       = each.value.count


### PR DESCRIPTION
The new variable allows setups where the cluster domain shouldn't contain the cluster id. This is required for the documented DNS scheme for APPUiO Cloud (cf. [APPUiO Cloud DNS scheme](https://kb.vshn.ch/appuio-cloud/references/dns-naming-scheme.html) vs [APPUiO Managed OCP4 DNS scheme](https://kb.vshn.ch/oc4/explanations/dns_scheme.html)).

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
