### PR TITLE
Remove the etcd SRV records

### DIFF
--- a/templates/dns.zone
+++ b/templates/dns.zone
@@ -12,7 +12,3 @@ ${lb_hostnames[i]} IN A     ${addr}
 %{ for i, addr in masters ~}
 etcd-${i} IN A     ${addr}
 %{ endfor ~}
-
-%{ for i, addr in masters ~}
-_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-${i}
-%{ endfor ~}


### PR DESCRIPTION
They are no longer required for OCP4.4+, according to https://access.redhat.com/solutions/5309701

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
