### PR TITLE
Cleanup DNS records

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,7 @@ output "dns_entries" {
     "node_name_suffix" = local.node_name_suffix,
     "api_vip"          = var.lb_count != 0 ? split("/", module.lb.api_vip[0].network)[0] : ""
     "router_vip"       = var.lb_count != 0 ? split("/", module.lb.router_vip[0].network)[0] : ""
+    "egress_vip"       = var.lb_count != 0 ? split("/", module.lb.nat_vip[0].network)[0] : ""
     "internal_vip"     = cidrhost(var.privnet_cidr, 100),
     "masters"          = module.master.ip_addresses,
     "cluster_id"       = var.cluster_id,

--- a/templates/dns.zone
+++ b/templates/dns.zone
@@ -3,7 +3,10 @@ $ORIGIN ${node_name_suffix}.
 
 api       IN A     ${api_vip}
 api-int   IN A     ${internal_vip}
-*.apps    IN A     ${router_vip}
+ingress   IN A     ${router_vip}
+egress    IN A     ${egress_vip}
+
+*.apps    IN CNAME ingress.${node_name_suffix}
 
 %{ for i, addr in lbs ~}
 ${lb_hostnames[i]} IN A     ${addr}

--- a/templates/dns.zone
+++ b/templates/dns.zone
@@ -12,7 +12,3 @@ ${lb_hostnames[i]} IN A     ${addr}
 %{ for i, addr in masters ~}
 etcd-${i} IN A     ${addr}
 %{ endfor ~}
-
-%{ for i, addr in masters ~}
-_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-${i}
-%{ endfor ~}


### PR DESCRIPTION
* Switch to an `ingress.` A record and make the wildcard `*.apps.` a
  CNAME. This allows adding more cnames pointing to the ingress.
* Add `egress.` A record matching the PTR record introduced earlier.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
