### PR TITLE
Use provider datasources when using an existing private network

### DIFF
--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -8,7 +8,7 @@ resource "cloudscale_server" "bootstrap" {
   interfaces {
     type = "private"
     addresses {
-      address     = cidrhost(var.privnet_cidr, 10)
+      address     = cidrhost(local.privnet_cidr, 10)
       subnet_uuid = local.subnet_uuid
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,8 @@ locals {
   node_name_suffix      = "${local.cluster_name}.${var.base_domain}"
   create_privnet_subnet = var.subnet_uuid == "" ? 1 : 0
   subnet_uuid           = var.subnet_uuid == "" ? cloudscale_subnet.privnet_subnet[0].id : var.subnet_uuid
-  privnet_uuid          = var.privnet_uuid == "" ? cloudscale_network.privnet[0].id : var.privnet_uuid
+  privnet_uuid          = local.create_privnet_subnet > 0 ? cloudscale_network.privnet[0].id : data.cloudscale_subnet.privnet_subnet[0].network_uuid
+  privnet_cidr          = local.create_privnet_subnet > 0 ? var.privnet_cidr : data.cloudscale_subnet.privnet_subnet[0].cidr
 }
 
 resource "cloudscale_network" "privnet" {
@@ -16,6 +17,11 @@ resource "cloudscale_network" "privnet" {
 resource "cloudscale_subnet" "privnet_subnet" {
   count           = local.create_privnet_subnet
   network_uuid    = local.privnet_uuid
-  cidr            = var.privnet_cidr
-  gateway_address = cidrhost(var.privnet_cidr, 1)
+  cidr            = local.privnet_cidr
+  gateway_address = cidrhost(local.privnet_cidr, 1)
+}
+
+data "cloudscale_subnet" "privnet_subnet" {
+  count = var.subnet_uuid == "" ? 0 : 1
+  id    = var.subnet_uuid
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "dns_entries" {
     "api_vip"          = var.lb_count != 0 ? split("/", module.lb.api_vip[0].network)[0] : ""
     "router_vip"       = var.lb_count != 0 ? split("/", module.lb.router_vip[0].network)[0] : ""
     "egress_vip"       = var.lb_count != 0 ? split("/", module.lb.nat_vip[0].network)[0] : ""
-    "internal_vip"     = cidrhost(var.privnet_cidr, 100),
+    "internal_vip"     = cidrhost(local.privnet_cidr, 100),
     "masters"          = module.master.ip_addresses,
     "cluster_id"       = var.cluster_id,
     "lbs"              = module.lb.public_ipv4_addresses,

--- a/variables.tf
+++ b/variables.tf
@@ -38,13 +38,7 @@ variable "ssh_keys" {
 
 variable "subnet_uuid" {
   type        = string
-  description = "UUID of the subnet in which to create the VMs"
-  default     = ""
-}
-
-variable "privnet_uuid" {
-  type        = string
-  description = "UUID of an existing private network. If provided, variables `privnet_cidr` and `subnet_uuid` must be set to point to a subnet which is part of the provided private network."
+  description = "UUID of an existing subnet. If provided, the variable `privnet_cidr` is ignored and the CIDR of the provided network is used."
   default     = ""
 }
 


### PR DESCRIPTION
By using  the cloudscale.ch provider datasource for subnets we can avoid having to specify `privnet_cidr` and `privnet_uuid` when using an existing subnet

This removes the variable `privnet_uuid`, which is technically a breaking change, but will only affect the few deployments that use the feature of reusing an exiting subnet.

See #43 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
