### PR TITLE
Switch to new cloudscale.ch node flavor for bootstrap node

### DIFF
--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -2,7 +2,7 @@ resource "cloudscale_server" "bootstrap" {
   count          = var.bootstrap_count
   name           = "bootstrap.${local.node_name_suffix}"
   zone_slug      = "${var.region}1"
-  flavor_slug    = "flex-16"
+  flavor_slug    = "flex-16-4"
   image_slug     = var.image_slug
   volume_size_gb = 128
   interfaces {


### PR DESCRIPTION
We seemed to have forgotten to update the flavor for the bootstrap node during https://github.com/appuio/terraform-openshift4-cloudscale/pull/61
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
