### PR TITLE
Change default root disk size to 100Gi

### DIFF
--- a/infra.tf
+++ b/infra.tf
@@ -7,6 +7,7 @@ module "infra" {
   node_name_suffix = local.node_name_suffix
   image_slug       = var.image_slug
   flavor_slug      = var.infra_flavor
+  volume_size_gb   = var.default_volume_size_gb
   subnet_uuid      = local.subnet_uuid
   ignition_ca      = var.ignition_ca
   api_int          = "api-int.${local.node_name_suffix}"

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
   subnet_uuid           = var.subnet_uuid == "" ? cloudscale_subnet.privnet_subnet[0].id : var.subnet_uuid
   privnet_uuid          = local.create_privnet_subnet > 0 ? cloudscale_network.privnet[0].id : data.cloudscale_subnet.privnet_subnet[0].network_uuid
   privnet_cidr          = local.create_privnet_subnet > 0 ? var.privnet_cidr : data.cloudscale_subnet.privnet_subnet[0].cidr
+  worker_volume_size_gb = var.worker_volume_size_gb == 0 ? var.default_volume_size_gb : var.worker_volume_size_gb
 }
 
 resource "cloudscale_network" "privnet" {

--- a/master.tf
+++ b/master.tf
@@ -8,6 +8,7 @@ module "master" {
   node_name_suffix = local.node_name_suffix
   image_slug       = var.image_slug
   flavor_slug      = var.master_flavor
+  volume_size_gb   = var.default_volume_size_gb
   subnet_uuid      = local.subnet_uuid
   ignition_ca      = var.ignition_ca
   api_int          = "api-int.${local.node_name_suffix}"

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -72,6 +72,7 @@ resource "cloudscale_server" "node" {
       skip_waiting_for_ssh_host_keys,
       image_slug,
       user_data,
+      volume_size_gb,
     ]
   }
 }

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -37,7 +37,7 @@ variable "image_slug" {
 variable "volume_size_gb" {
   type        = number
   description = "Boot volume size in GBs"
-  default     = 128
+  default     = 100
 }
 
 variable "ignition_ca" {

--- a/variables.tf
+++ b/variables.tf
@@ -104,10 +104,16 @@ variable "worker_flavor" {
   description = "Flavor to use for worker nodes"
 }
 
+variable "default_volume_size_gb" {
+  type        = number
+  description = "Default boot volume size in GBs"
+  default     = 100
+}
+
 variable "worker_volume_size_gb" {
   type        = number
   description = "Worker boot volume size in GBs"
-  default     = 128
+  default     = 0
 }
 
 variable "additional_worker_groups" {
@@ -119,12 +125,12 @@ variable "additional_worker_groups" {
       for k, v in var.additional_worker_groups :
       !contains(["worker", "master", "infra"], k) &&
       v.count >= 0 &&
-      (v.volume_size_gb != null ? v.volume_size_gb >= 120 : true)
+      (v.volume_size_gb != null ? v.volume_size_gb >= 100 : true)
     ])
     // Cannot use any of the nicer string formatting options because
     // error_message validation is dumb, cf.
     // https://github.com/hashicorp/terraform/issues/24123
-    error_message = "Your configuration of `additional_worker_groups` violates one of the following constraints:\n * The worker disk size cannot be smaller than 120GB.\n * Additional worker group names cannot be 'worker', 'master', or 'infra'.\n * The worker count cannot be less than 0."
+    error_message = "Your configuration of `additional_worker_groups` violates one of the following constraints:\n * The worker disk size cannot be smaller than 100GB.\n * Additional worker group names cannot be 'worker', 'master', or 'infra'.\n * The worker count cannot be less than 0."
   }
 }
 

--- a/worker.tf
+++ b/worker.tf
@@ -7,7 +7,7 @@ module "worker" {
   node_name_suffix = local.node_name_suffix
   image_slug       = var.image_slug
   flavor_slug      = var.worker_flavor
-  volume_size_gb   = var.worker_volume_size_gb
+  volume_size_gb   = local.worker_volume_size_gb
   subnet_uuid      = local.subnet_uuid
   ignition_ca      = var.ignition_ca
   api_int          = "api-int.${local.node_name_suffix}"
@@ -26,7 +26,7 @@ module "additional_worker" {
   node_name_suffix = local.node_name_suffix
   image_slug       = var.image_slug
   flavor_slug      = each.value.flavor
-  volume_size_gb   = each.value.volume_size_gb != null ? each.value.volume_size_gb : var.worker_volume_size_gb
+  volume_size_gb   = each.value.volume_size_gb != null ? each.value.volume_size_gb : local.worker_volume_size_gb
   subnet_uuid      = local.subnet_uuid
   ignition_ca      = var.ignition_ca
   api_int          = "api-int.${local.node_name_suffix}"


### PR DESCRIPTION
RedHat lowered requirements for OpenShift node root disk size to 100Gi. 
This change also makes the default root disk size configurable.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
