### PR TITLE
Set cloudscale.ch instance UUID as node `providerID`

### DIFF
--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -39,6 +39,22 @@ locals {
             TTYPath=/dev/ttyS0
             ExecStart=/bin/sh -c "echo '-----BEGIN SSH HOST KEY KEYS-----'; cat /etc/ssh/ssh_host_*key.pub; echo '-----END SSH HOST KEY KEYS-----'"
             EOC
+          },
+          {
+            "name": "kubelet.service",
+            "dropins": [
+              {
+                "name": "appuio-provider-id.conf",
+                "contents": <<-EOC
+                # Managed through terraform-openshift4-cloudscale
+                [Service]
+                ExecStartPre=/bin/bash -c \
+                  'echo "KUBELET_PROVIDERID=\"cloudscale://$(curl http://169.254.169.254/openstack/2017-02-22/meta_data.json | \
+                    jq -r .meta.cloudscale_uuid)\"" > /run/appuio-provider-id.env'
+                EnvironmentFile=-/run/appuio-provider-id.env
+                EOC
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
We deploy a systemd dropin for the `kubelet` service which fetches the node's cloudscale.ch UUID from the metadata service and passes it to the kubelet as the value for `--provider-id`. Note that OpenShift itself already sets flag `--provider-id=${KUBELET_PROVIDERID}` in the kubelet systemd service.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
