### PR TITLE
Allow node adoption by the new cloudscale provider

### DIFF
--- a/infra.tf
+++ b/infra.tf
@@ -1,14 +1,16 @@
 module "infra" {
   source = "./modules/node-group"
 
-  region           = var.region
-  role             = "infra"
-  node_count       = var.infra_count
-  node_name_suffix = local.node_name_suffix
-  image_slug       = var.image_slug
-  flavor_slug      = var.infra_flavor
-  volume_size_gb   = var.default_volume_size_gb
-  subnet_uuid      = local.subnet_uuid
-  ignition_ca      = var.ignition_ca
-  api_int          = "api-int.${local.node_name_suffix}"
+  region                     = var.region
+  role                       = "infra"
+  node_count                 = var.infra_count
+  node_name_suffix           = local.node_name_suffix
+  image_slug                 = var.image_slug
+  flavor_slug                = var.infra_flavor
+  volume_size_gb             = var.default_volume_size_gb
+  subnet_uuid                = local.subnet_uuid
+  ignition_ca                = var.ignition_ca
+  api_int                    = "api-int.${local.node_name_suffix}"
+  cluster_id                 = var.cluster_id
+  make_adoptable_by_provider = var.make_worker_adoptable_by_provider
 }

--- a/master.tf
+++ b/master.tf
@@ -1,15 +1,17 @@
 module "master" {
   source = "./modules/node-group"
 
-  region           = var.region
-  role             = "master"
-  ignition_config  = "master"
-  node_count       = var.master_count
-  node_name_suffix = local.node_name_suffix
-  image_slug       = var.image_slug
-  flavor_slug      = var.master_flavor
-  volume_size_gb   = var.default_volume_size_gb
-  subnet_uuid      = local.subnet_uuid
-  ignition_ca      = var.ignition_ca
-  api_int          = "api-int.${local.node_name_suffix}"
+  region                     = var.region
+  role                       = "master"
+  ignition_config            = "master"
+  node_count                 = var.master_count
+  node_name_suffix           = local.node_name_suffix
+  image_slug                 = var.image_slug
+  flavor_slug                = var.master_flavor
+  volume_size_gb             = var.default_volume_size_gb
+  subnet_uuid                = local.subnet_uuid
+  ignition_ca                = var.ignition_ca
+  api_int                    = "api-int.${local.node_name_suffix}"
+  cluster_id                 = var.cluster_id
+  make_adoptable_by_provider = var.make_master_adoptable_by_provider
 }

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -30,6 +30,12 @@ resource "cloudscale_server" "node" {
       subnet_uuid = var.subnet_uuid
     }
   }
+
+  tags = var.make_adoptable_by_provider ? {
+    "machine-api-provider-cloudscale_appuio_io_name" : random_id.node[count.index].hex
+    } : {
+  }
+
   user_data = <<-EOF
     {
       "ignition": {

--- a/modules/node-group/outputs.tf
+++ b/modules/node-group/outputs.tf
@@ -1,3 +1,111 @@
 output "ip_addresses" {
   value = cloudscale_server.node[*].private_ipv4_address
 }
+
+locals {
+  machine_spec = {
+    "lifecycleHooks" = {}
+    "metadata" = {
+      labels = var.role == "master" ? {
+        "node-role.kubernetes.io/control-plane" = ""
+        "node-role.kubernetes.io/master"        = ""
+        } : (var.role == "worker" ? {
+          // Legacy case, "worker" nodes without additional specification are the "app" nodes of the cluster
+          "node-role.kubernetes.io/app"    = ""
+          "node-role.kubernetes.io/worker" = ""
+          } : {
+          "node-role.kubernetes.io/${var.role}" = ""
+          "node-role.kubernetes.io/worker"      = ""
+
+      })
+    }
+    "providerSpec" = {
+      "value" = {
+        "zone"             = "${var.region}1"
+        "baseDomain"       = var.node_name_suffix
+        "flavor"           = var.flavor_slug
+        "image"            = var.image_slug
+        "rootVolumeSizeGB" = var.volume_size_gb
+        "antiAffinityKey"  = var.role
+        "userDataSecret" = {
+          "name" = "cloudscale-user-data"
+        }
+        "tokenSecret" = {
+          "name" = "cloudscale-rw-token"
+        }
+        "interfaces" = [{
+          "type" = "Private"
+          "addresses" = [{
+            "subnetUUID" = var.subnet_uuid,
+          }]
+        }]
+      }
+    }
+  }
+
+  machines = [
+    for id in random_id.node : {
+      "apiVersion" = "machine.openshift.io/v1beta1"
+      "kind"       = "Machine"
+      "metadata" = {
+        "name"        = id.hex
+        "annotations" = {}
+        "labels" = {
+          "machine.openshift.io/cluster-api-cluster"    = var.cluster_id
+          "machine.openshift.io/cluster-api-machineset" = var.role
+        }
+      }
+      "spec" = local.machine_spec
+    }
+  ]
+}
+
+output "machines" {
+  value = local.machines
+}
+
+output "machine_yml" {
+  value = yamlencode({
+    "apiVersion" = "v1",
+    "kind"       = "List",
+    "items"      = local.machines,
+  })
+}
+
+output "machineset_yml" {
+  value = yamlencode({
+    "apiVersion" = "machine.openshift.io/v1beta1",
+    "kind"       = "MachineSet",
+    "metadata" = {
+      "name"      = var.role,
+      "namespace" = "openshift-machine-api",
+      "labels" = {
+        "machine.openshift.io/cluster-api-cluster" = var.cluster_id,
+        "name"                                     = var.role,
+      },
+    },
+    "spec" = {
+      "deletePolicy" = "Oldest",
+      "replicas"     = var.node_count,
+      "selector" = {
+        "matchLabels" = {
+          "machine.openshift.io/cluster-api-cluster"    = var.cluster_id,
+          "machine.openshift.io/cluster-api-machineset" = var.role
+        }
+      },
+      "template" = {
+        "metadata" = {
+          "labels" = {
+            "machine.openshift.io/cluster-api-cluster" = var.cluster_id,
+            // Legacy case, "worker" nodes without additional specification are the "app" nodes of the cluster
+            "machine.openshift.io/cluster-api-machine-role" = var.role == "worker" ? "app" : var.role,
+            "machine.openshift.io/cluster-api-machine-type" = var.role == "worker" ? "app" : var.role,
+            "machine.openshift.io/cluster-api-machineset"   = var.role,
+          }
+        },
+        "spec" = local.machine_spec,
+      },
+    },
+    }
+  )
+}

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -55,3 +55,14 @@ variable "api_int" {
   type        = string
   description = "Hostname of the internal API (to be used for the ignition endpoint)"
 }
+
+variable "cluster_id" {
+  type        = string
+  description = "ID of the cluster to which the nodes belong, used for rendering machines and  machine sets"
+}
+
+variable "make_adoptable_by_provider" {
+  type        = bool
+  description = "Whether to make the nodes adoptable by https://github.com/appuio/machine-api-provider-cloudscale"
+  default     = false
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,3 +40,39 @@ output "api_int" {
 output "hieradata_mr" {
   value = module.lb.hieradata_mr_url
 }
+
+output "master-machines_yml" {
+  value = var.make_master_adoptable_by_provider ? module.master.machine_yml : null
+}
+
+output "master-machineset_yml" {
+  value = var.make_master_adoptable_by_provider ? module.master.machineset_yml : null
+}
+
+output "infra-machines_yml" {
+  value = var.make_worker_adoptable_by_provider ? module.infra.machine_yml : null
+}
+
+output "infra-machineset_yml" {
+  value = var.make_worker_adoptable_by_provider ? module.infra.machineset_yml : null
+}
+
+output "worker-machines_yml" {
+  value = var.make_worker_adoptable_by_provider ? module.worker.machine_yml : null
+}
+
+output "worker-machineset_yml" {
+  value = var.make_worker_adoptable_by_provider ? module.worker.machineset_yml : null
+}
+
+output "additional-worker-machines_yml" {
+  value = var.make_worker_adoptable_by_provider && length(module.additional_worker) > 0 ? {
+    "apiVersion" = "v1",
+    "kind"       = "List",
+    "items"      = flatten(values(module.additional_worker)[*].machines)
+  } : null
+}
+
+output "additional-worker-machinesets_yml" {
+  value = var.make_worker_adoptable_by_provider && length(module.additional_worker) > 0 ? join("\n---\n", values(module.additional_worker)[*].machineset_yml) : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -205,3 +205,15 @@ variable "internal_router_vip" {
   description = "Custom internal floating IP for the router. Users must provide an IP that's within the final privnet CIDR."
   default     = ""
 }
+
+variable "make_worker_adoptable_by_provider" {
+  type        = bool
+  description = "Whether to make the worker nodes adoptable by https://github.com/appuio/machine-api-provider-cloudscale"
+  default     = false
+}
+
+variable "make_master_adoptable_by_provider" {
+  type        = bool
+  description = "Whether to make the master nodes adoptable by https://github.com/appuio/machine-api-provider-cloudscale"
+  default     = false
+}

--- a/worker.tf
+++ b/worker.tf
@@ -1,16 +1,18 @@
 module "worker" {
   source = "./modules/node-group"
 
-  region           = var.region
-  role             = "worker"
-  node_count       = var.worker_count
-  node_name_suffix = local.node_name_suffix
-  image_slug       = var.image_slug
-  flavor_slug      = var.worker_flavor
-  volume_size_gb   = local.worker_volume_size_gb
-  subnet_uuid      = local.subnet_uuid
-  ignition_ca      = var.ignition_ca
-  api_int          = "api-int.${local.node_name_suffix}"
+  region                     = var.region
+  role                       = "worker"
+  node_count                 = var.worker_count
+  node_name_suffix           = local.node_name_suffix
+  image_slug                 = var.image_slug
+  flavor_slug                = var.worker_flavor
+  volume_size_gb             = local.worker_volume_size_gb
+  subnet_uuid                = local.subnet_uuid
+  ignition_ca                = var.ignition_ca
+  api_int                    = "api-int.${local.node_name_suffix}"
+  cluster_id                 = var.cluster_id
+  make_adoptable_by_provider = var.make_worker_adoptable_by_provider
 }
 
 // Additional worker groups.
@@ -20,14 +22,16 @@ module "additional_worker" {
 
   source = "./modules/node-group"
 
-  region           = var.region
-  role             = each.key
-  node_count       = each.value.count
-  node_name_suffix = local.node_name_suffix
-  image_slug       = var.image_slug
-  flavor_slug      = each.value.flavor
-  volume_size_gb   = each.value.volume_size_gb != null ? each.value.volume_size_gb : local.worker_volume_size_gb
-  subnet_uuid      = local.subnet_uuid
-  ignition_ca      = var.ignition_ca
-  api_int          = "api-int.${local.node_name_suffix}"
+  region                     = var.region
+  role                       = each.key
+  node_count                 = each.value.count
+  node_name_suffix           = local.node_name_suffix
+  image_slug                 = var.image_slug
+  flavor_slug                = each.value.flavor
+  volume_size_gb             = each.value.volume_size_gb != null ? each.value.volume_size_gb : local.worker_volume_size_gb
+  subnet_uuid                = local.subnet_uuid
+  ignition_ca                = var.ignition_ca
+  api_int                    = "api-int.${local.node_name_suffix}"
+  cluster_id                 = var.cluster_id
+  make_adoptable_by_provider = var.make_worker_adoptable_by_provider
 }


### PR DESCRIPTION
Allows nodes to be adopted by https://github.com/appuio/machine-api-provider-cloudscale.

When setting `var.make_worker_adoptable_by_provider` or `var.make_master_adoptable_by_provider` the servers are tagged with the correct tags so the provider recognises them and matching `Machine`/`MachineSet` manifests are written to the outputs module.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
