### PR TITLE
Introduce variable to control whether IPv6 floating IP addresses are allocated

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -87,7 +87,7 @@ data "cloudscale_floating_ip" "api_v4" {
 }
 
 resource "cloudscale_floating_ip" "api_v6" {
-  count         = var.enable_api_lbaas && !var.use_existing_vips ? 1 : 0
+  count         = var.enable_api_lbaas && var.enable_v6_vips && !var.use_existing_vips ? 1 : 0
   load_balancer = module.lb_api.lb_id
   region_slug   = var.region
   ip_version    = 6
@@ -95,7 +95,7 @@ resource "cloudscale_floating_ip" "api_v6" {
 }
 
 data "cloudscale_floating_ip" "api_v6" {
-  count       = var.enable_api_lbaas && var.use_existing_vips ? 1 : 0
+  count       = var.enable_api_lbaas && var.enable_v6_vips && var.use_existing_vips ? 1 : 0
   ip_version  = 6
   reverse_ptr = "api.${local.node_name_suffix}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,7 @@ locals {
   cloudscale_router_vip = var.enable_router_vip ? (var.allocate_router_vip_for_lb_controller ? split("/", (var.use_existing_vips ? data.cloudscale_floating_ip.router_vip[0] : cloudscale_floating_ip.router_vip[0]).network)[0] : split("/", module.lb.router_vip[0].network)[0]) : ""
 
   api_vip_v4 = var.enable_api_lbaas ? (var.use_existing_vips ? data.cloudscale_floating_ip.api_v4[0].id : cloudscale_floating_ip.api_v4[0].id) : module.lb.api_vip[0].id
-  api_vip_v6 = var.enable_api_lbaas ? (var.use_existing_vips ? data.cloudscale_floating_ip.api_v6[0].id : cloudscale_floating_ip.api_v6[0].id) : ""
+  api_vip_v6 = var.enable_api_lbaas && var.enable_v6_vips ? (var.use_existing_vips ? data.cloudscale_floating_ip.api_v6[0].id : cloudscale_floating_ip.api_v6[0].id) : ""
 
   router_vip = var.allocate_router_vip_for_lb_controller && !var.enable_router_vip ? var.internal_router_vip : local.cloudscale_router_vip
 }

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "enable_nat_vip" {
   default     = true
 }
 
+variable "enable_v6_vips" {
+  type        = bool
+  description = "Whether to allocate a cloudscale IPv6 floating IP for the API"
+  default     = true
+}
+
 variable "internal_vip" {
   type        = string
   description = "Custom internal floating IP for the API. Users must provide an IP that's within the final privnet CIDR."


### PR DESCRIPTION
The variable defaults to true. Note that the module currently only allocates an IPv6 floating IP for the API and only if a cloudscale LBaaS instance is provisioned for the API.

Follow-up for #113 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
