### PR TITLE
Allocate a cloudscale IPv6 floating IP for the ingress router

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -51,6 +51,32 @@ data "cloudscale_floating_ip" "router_vip" {
   reverse_ptr = "ingress.${local.node_name_suffix}"
 }
 
+resource "cloudscale_floating_ip" "router_vip_v6" {
+  count       = var.enable_router_vip && var.allocate_router_vip_for_lb_controller && var.enable_v6_vips && !var.use_existing_vips ? 1 : 0
+  ip_version  = 6
+  region_slug = var.region
+  reverse_ptr = "ingress.${local.node_name_suffix}"
+
+  tags = {
+    appuio_io_vip_id = "${var.cluster_id}:ingress"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to server for migration
+      server,
+      # Will be handled by the cloudscale-loadbalancer-controller
+      load_balancer,
+    ]
+  }
+}
+
+data "cloudscale_floating_ip" "router_vip_v6" {
+  count       = var.enable_router_vip && var.allocate_router_vip_for_lb_controller && var.enable_v6_vips && var.use_existing_vips ? 1 : 0
+  ip_version  = 6
+  reverse_ptr = "ingress.${local.node_name_suffix}"
+}
+
 module "lb_api" {
   source = "./modules/cloudscale-lb"
   create = var.enable_api_lbaas

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,13 @@
 locals {
   cloudscale_router_vip = var.enable_router_vip ? (var.allocate_router_vip_for_lb_controller ? split("/", (var.use_existing_vips ? data.cloudscale_floating_ip.router_vip[0] : cloudscale_floating_ip.router_vip[0]).network)[0] : split("/", module.lb.router_vip[0].network)[0]) : ""
 
+  cloudscale_router_vip_v6 = var.enable_router_vip && var.enable_v6_vips ? (var.allocate_router_vip_for_lb_controller ? split("/", (var.use_existing_vips ? data.cloudscale_floating_ip.router_vip_v6[0] : cloudscale_floating_ip.router_vip_v6[0]).network)[0] : "") : ""
+
   api_vip_v4 = var.enable_api_lbaas ? (var.use_existing_vips ? data.cloudscale_floating_ip.api_v4[0].id : cloudscale_floating_ip.api_v4[0].id) : module.lb.api_vip[0].id
   api_vip_v6 = var.enable_api_lbaas && var.enable_v6_vips ? (var.use_existing_vips ? data.cloudscale_floating_ip.api_v6[0].id : cloudscale_floating_ip.api_v6[0].id) : ""
 
-  router_vip = var.allocate_router_vip_for_lb_controller && !var.enable_router_vip ? var.internal_router_vip : local.cloudscale_router_vip
+  router_vip_v4 = var.allocate_router_vip_for_lb_controller && !var.enable_router_vip ? var.internal_router_vip : local.cloudscale_router_vip
+  router_vip_v6 = var.allocate_router_vip_for_lb_controller && var.enable_router_vip ? local.cloudscale_router_vip_v6 : ""
 }
 
 output "dns_entries" {
@@ -12,7 +15,8 @@ output "dns_entries" {
     "node_name_suffix"    = local.node_name_suffix,
     "api_vip"             = local.api_vip_v4
     "api_vip_v6"          = local.api_vip_v6
-    "router_vip"          = local.router_vip
+    "router_vip"          = local.router_vip_v4
+    "router_vip_v6"       = local.router_vip_v6
     "egress_vip"          = var.enable_nat_vip && var.lb_count != 0 ? split("/", module.lb.nat_vip[0].network)[0] : ""
     "internal_vip"        = local.internal_vip,
     "internal_router_vip" = var.internal_router_vip,
@@ -44,7 +48,11 @@ output "api_int_vip" {
 }
 
 output "router_vip" {
-  value = local.router_vip
+  value = local.router_vip_v4
+}
+
+output "router_vip_v6" {
+  value = local.router_vip_v6
 }
 
 output "region" {

--- a/templates/dns.zone
+++ b/templates/dns.zone
@@ -11,6 +11,9 @@ api-int     IN A     ${internal_vip}
 %{ if router_vip != "" ~}
 ingress     IN A     ${router_vip}
 %{ endif ~}
+%{ if router_vip_v6 != "" ~}
+ingress     IN AAAA  ${router_vip_v6}
+%{ endif ~}
 %{ if internal_router_vip != "" ~}
 ingress-int IN A     ${internal_router_vip}
 %{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -208,7 +208,7 @@ variable "enable_nat_vip" {
 
 variable "enable_v6_vips" {
   type        = bool
-  description = "Whether to allocate a cloudscale IPv6 floating IP for the API"
+  description = "Whether to allocate cloudscale IPv6 floating IPs for the API and ingress router"
   default     = true
 }
 


### PR DESCRIPTION
Note that we only allocate an IPv6 floating IP for the ingress router when we allocate floating IPs for the in-cluster cloudscale LB controller.

Additionally, we only allocate an IPv6 floating IP for the ingress router when the new `enable_v6_vips` variable (#115) is set to true.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
