### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate the Renovate preset from deprecated `config:base` to `config:recommended`
- preserve the existing Renovate configuration shape

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

I did not run Terraform/OpenShift provisioning tests for this config-only Renovate change.

Addresses the Renovate dashboard's Config Migration Needed item in #39.